### PR TITLE
Fix permission settings opening for iOS 18

### DIFF
--- a/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/Extensions.ios.kt
+++ b/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/Extensions.ios.kt
@@ -6,6 +6,8 @@ import platform.UIKit.UIApplicationOpenSettingsURLString
 
 internal actual fun openPermissionSettings() {
     UIApplication.sharedApplication().openURL(
-        url = NSURL(string = UIApplicationOpenSettingsURLString)
+        url = NSURL(string = UIApplicationOpenSettingsURLString),
+        options = emptyMap<Any?, Any>(),
+        completionHandler = null
     )
 }


### PR DESCRIPTION
Hi 👋
Opening settings doesn't work in iOS 18. You can read more about this problem here (https://forums.developer.apple.com/forums/thread/763568)
I've corrected the URL opening, now everything works!