### PR TITLE
Use SettingsClient on Android to detect if location is enabled

### DIFF
--- a/compass-geolocation-browser/src/commonMain/kotlin/dev/jordond/compass/geolocation/browser/internal/DefaultBrowserLocator.kt
+++ b/compass-geolocation-browser/src/commonMain/kotlin/dev/jordond/compass/geolocation/browser/internal/DefaultBrowserLocator.kt
@@ -40,7 +40,7 @@ internal class DefaultBrowserLocator : BrowserLocator {
     )
     override val locationUpdates: Flow<Location> = _locationUpdates
 
-    override fun isAvailable(): Boolean {
+    override suspend fun isAvailable(): Boolean {
         return navigator?.geolocation != null
     }
 

--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/MobileLocator.android.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/MobileLocator.android.kt
@@ -33,7 +33,7 @@ internal class AndroidLocator(
     override val locationUpdates: Flow<Location> = locationManager.locationUpdates
         .mapNotNull { result -> result.lastLocation?.toModel() }
 
-    override fun isAvailable(): Boolean {
+    override suspend fun isAvailable(): Boolean {
         return locationManager.locationEnabled()
     }
 

--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/LocationManager.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/LocationManager.kt
@@ -48,10 +48,10 @@ internal class LocationManager(
     suspend fun locationEnabled(): Boolean {
         val request = LocationSettingsRequest.Builder().addAllLocationRequests(
             listOf(
-                LocationRequest.Builder(PRIORITY_HIGH_ACCURACY, 100).build(),
-                LocationRequest.Builder(PRIORITY_BALANCED_POWER_ACCURACY, 100).build(),
-                LocationRequest.Builder(PRIORITY_PASSIVE, 100).build(),
-                LocationRequest.Builder(PRIORITY_LOW_POWER, 100).build(),
+                LocationRequest.Builder(PRIORITY_HIGH_ACCURACY, 1000).build(),
+                LocationRequest.Builder(PRIORITY_BALANCED_POWER_ACCURACY, 1000).build(),
+                LocationRequest.Builder(PRIORITY_PASSIVE, 1000).build(),
+                LocationRequest.Builder(PRIORITY_LOW_POWER, 1000).build(),
             )
         ).build()
 

--- a/compass-geolocation-mobile/src/iosMain/kotlin/dev/jordond/compass/geolocation/mobile/MobileLocator.ios.kt
+++ b/compass-geolocation-mobile/src/iosMain/kotlin/dev/jordond/compass/geolocation/mobile/MobileLocator.ios.kt
@@ -43,7 +43,7 @@ internal class IosLocator(
         }
     }
 
-    override fun isAvailable(): Boolean {
+    override suspend fun isAvailable(): Boolean {
         return CLLocationManager.locationServicesEnabled()
     }
 

--- a/compass-geolocation/api/android/compass-geolocation.api
+++ b/compass-geolocation/api/android/compass-geolocation.api
@@ -10,7 +10,7 @@ public abstract interface class dev/jordond/compass/geolocation/Geolocator {
 	public abstract fun current (Ldev/jordond/compass/Priority;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLocationUpdates ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getTrackingStatus ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun isAvailable ()Z
+	public abstract fun isAvailable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun startTracking (Ldev/jordond/compass/geolocation/LocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stopTracking ()V
 	public abstract fun track (Ldev/jordond/compass/geolocation/LocationRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -136,7 +136,7 @@ public abstract interface class dev/jordond/compass/geolocation/Locator {
 	public static final field Companion Ldev/jordond/compass/geolocation/Locator$Companion;
 	public abstract fun current (Ldev/jordond/compass/Priority;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLocationUpdates ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun isAvailable ()Z
+	public abstract fun isAvailable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stopTracking ()V
 	public abstract fun track (Ldev/jordond/compass/geolocation/LocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -153,7 +153,7 @@ public final class dev/jordond/compass/geolocation/NotSupportedLocator : dev/jor
 	public static final field INSTANCE Ldev/jordond/compass/geolocation/NotSupportedLocator;
 	public fun current (Ldev/jordond/compass/Priority;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLocationUpdates ()Lkotlinx/coroutines/flow/Flow;
-	public fun isAvailable ()Z
+	public fun isAvailable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stopTracking ()V
 	public fun track (Ldev/jordond/compass/geolocation/LocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/compass-geolocation/api/jvm/compass-geolocation.api
+++ b/compass-geolocation/api/jvm/compass-geolocation.api
@@ -10,7 +10,7 @@ public abstract interface class dev/jordond/compass/geolocation/Geolocator {
 	public abstract fun current (Ldev/jordond/compass/Priority;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLocationUpdates ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getTrackingStatus ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun isAvailable ()Z
+	public abstract fun isAvailable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun startTracking (Ldev/jordond/compass/geolocation/LocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stopTracking ()V
 	public abstract fun track (Ldev/jordond/compass/geolocation/LocationRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -136,7 +136,7 @@ public abstract interface class dev/jordond/compass/geolocation/Locator {
 	public static final field Companion Ldev/jordond/compass/geolocation/Locator$Companion;
 	public abstract fun current (Ldev/jordond/compass/Priority;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLocationUpdates ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun isAvailable ()Z
+	public abstract fun isAvailable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stopTracking ()V
 	public abstract fun track (Ldev/jordond/compass/geolocation/LocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -153,7 +153,7 @@ public final class dev/jordond/compass/geolocation/NotSupportedLocator : dev/jor
 	public static final field INSTANCE Ldev/jordond/compass/geolocation/NotSupportedLocator;
 	public fun current (Ldev/jordond/compass/Priority;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLocationUpdates ()Lkotlinx/coroutines/flow/Flow;
-	public fun isAvailable ()Z
+	public fun isAvailable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stopTracking ()V
 	public fun track (Ldev/jordond/compass/geolocation/LocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/compass-geolocation/src/commonMain/kotlin/dev/jordond/compass/geolocation/Geolocator.kt
+++ b/compass-geolocation/src/commonMain/kotlin/dev/jordond/compass/geolocation/Geolocator.kt
@@ -46,7 +46,7 @@ public interface Geolocator {
      *
      * @return `true` if location services are available, `false` otherwise.
      */
-    public fun isAvailable(): Boolean
+    public suspend fun isAvailable(): Boolean
 
     /**
      * Get the current location.

--- a/compass-geolocation/src/commonMain/kotlin/dev/jordond/compass/geolocation/Locator.kt
+++ b/compass-geolocation/src/commonMain/kotlin/dev/jordond/compass/geolocation/Locator.kt
@@ -28,7 +28,7 @@ public interface Locator {
     /**
      * Check if the platform supports geolocation.
      */
-    public fun isAvailable(): Boolean
+    public suspend fun isAvailable(): Boolean
 
     /**
      * Get the current location.
@@ -86,7 +86,7 @@ public interface PermissionLocator : Locator {
 public object NotSupportedLocator : Locator {
 
     override val locationUpdates: Flow<Location> = emptyFlow()
-    override fun isAvailable(): Boolean = false
+    override suspend fun isAvailable(): Boolean = false
     override suspend fun current(priority: Priority): Location = throw NotSupportedException()
     override suspend fun track(request: LocationRequest): Flow<Location> = emptyFlow()
     override fun stopTracking() {}

--- a/compass-geolocation/src/commonMain/kotlin/dev/jordond/compass/geolocation/internal/DefaultGeolocator.kt
+++ b/compass-geolocation/src/commonMain/kotlin/dev/jordond/compass/geolocation/internal/DefaultGeolocator.kt
@@ -43,7 +43,7 @@ internal class DefaultGeolocator(
 
     override val trackingStatus: Flow<TrackingStatus> = status
 
-    override fun isAvailable(): Boolean = locator.isAvailable()
+    override suspend fun isAvailable(): Boolean = locator.isAvailable()
 
     override suspend fun current(priority: Priority): GeolocatorResult {
         return handleResult { locator.current(priority) }

--- a/demo/composeApp/src/commonMain/kotlin/geolocation/GeolocationModel.kt
+++ b/demo/composeApp/src/commonMain/kotlin/geolocation/GeolocationModel.kt
@@ -17,8 +17,10 @@ import kotlinx.coroutines.launch
 class GeolocationModel(private val geolocator: Geolocator) : StateScreenModel<State>(State()) {
 
     init {
-        val isAvailable = geolocator.isAvailable()
-        updateState { it.copy(locationServiceAvailable = isAvailable) }
+        screenModelScope.launch {
+            val isAvailable = geolocator.isAvailable()
+            updateState { it.copy(locationServiceAvailable = isAvailable) }
+        }
 
         geolocator.trackingStatus
             .onEach { status ->


### PR DESCRIPTION
While looking into #169 I discovered the new way to check if location services are available for Android devices.

This PR modifies `LocationManager.locationEnabled()` to use the `SettingsClient` API to check whether or not location services are enabled on the device. It still falls back to the legacy method of checking the `LocationManager.isProviderEnabled`

One downside to this approach is `Geolocator.isAvailable()` is once again a `suspend fun`. Which completely undoes the efforts of #105. 