### PR TITLE
Correctly name the compass-geolocation and compass-geolocation-browser artifacts

### DIFF
--- a/docs/geolocation/browser.md
+++ b/docs/geolocation/browser.md
@@ -1,6 +1,6 @@
 # 🖥️ Browser
 
-Compass supports [HTML5 Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation\_API) with the `compass-geolocator-browser` artifact. The artifact supports JS and WASM targets.
+Compass supports [HTML5 Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation\_API) with the `compass-geolocation-browser` artifact. The artifact supports JS and WASM targets.
 
 Geolocation in the browser requires the user to provide permission. This is handled automatically when you start tracking or attempt to get the current location.
 

--- a/docs/geolocation/geolocator.md
+++ b/docs/geolocation/geolocator.md
@@ -1,6 +1,6 @@
 # 🔍 Geolocator
 
-The `compass-geolocator` artifact provides an interface `Geolocator` that has members for:
+The `compass-geolocation` artifact provides an interface `Geolocator` that has members for:
 
 * Getting the current location
 * Starting and stopping tracking the location


### PR DESCRIPTION
This would have saved me quite a bit of time on a hackathon I just went to. I also blame Android Studio for not telling me the artifacts couldn't be found, but still..