### PR TITLE
[iOS] Prevent requestPermission callback from invoking multiple times and overriding permissionCallback

### DIFF
--- a/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/internal/LocationPermissionManagerDelegate.kt
+++ b/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/internal/LocationPermissionManagerDelegate.kt
@@ -10,6 +10,7 @@ internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManager
     internal val manager = CLLocationManager()
 
     private var permissionCallback: ((CLAuthorizationStatus) -> Unit)? = null
+    private var requestPermissionCallback: ((CLAuthorizationStatus) -> Unit)? = null
 
     init {
         manager.delegate = this
@@ -25,11 +26,16 @@ internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManager
     }
 
     override fun locationManagerDidChangeAuthorization(manager: CLLocationManager) {
-        permissionCallback?.invoke(manager.authorizationStatus)
+        val status = manager.authorizationStatus
+        permissionCallback?.invoke(status)
+        requestPermissionCallback?.invoke(status)
     }
 
     fun requestPermission(callback: (CLAuthorizationStatus) -> Unit) {
-        permissionCallback = callback
+        requestPermissionCallback = { status ->
+            callback(status)
+            requestPermissionCallback = null
+        }
         manager.requestAlwaysAuthorization()
     }
 }


### PR DESCRIPTION
Fixes #71

Overriding `permissionCallback` in `requestPermission` caused 2 problems.
1. It allowed invoking the `continuation.resume(it)` in `requestPermission`'s callback more than once, which leads to a crash #71
2. It stops invoking the original `permissionCallback`, thus stopping updates of `_permissionsStatus` in `PermissionController`.

This PR fixes both of these problems.