### PR TITLE
[iOS] Allow requesting When In Use Authorization

### DIFF
--- a/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/internal/LocationPermissionManagerDelegate.kt
+++ b/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/internal/LocationPermissionManagerDelegate.kt
@@ -3,6 +3,7 @@ package dev.jordond.compass.permissions.mobile.internal
 import platform.CoreLocation.CLAuthorizationStatus
 import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.Foundation.NSBundle
 import platform.darwin.NSObject
 
 internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManagerDelegateProtocol {
@@ -11,8 +12,15 @@ internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManager
 
     private var permissionCallback: ((CLAuthorizationStatus) -> Unit)? = null
 
+    private val useAlwaysAuthorization = canUseAlwaysAuthorization()
+    
     init {
         manager.delegate = this
+    }
+
+    private fun canUseAlwaysAuthorization(): Boolean {
+        return NSBundle.mainBundle.infoDictionary
+            ?.containsKey("NSLocationAlwaysAndWhenInUseUsageDescription") ?: false
     }
 
     fun currentPermissionStatus(): CLAuthorizationStatus {
@@ -30,6 +38,11 @@ internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManager
 
     fun requestPermission(callback: (CLAuthorizationStatus) -> Unit) {
         permissionCallback = callback
-        manager.requestAlwaysAuthorization()
+        
+        if (useAlwaysAuthorization) {
+            manager.requestAlwaysAuthorization()
+        } else {
+            manager.requestWhenInUseAuthorization()
+        }
     }
 }


### PR DESCRIPTION
Fixes #72

The code checks whether user has defined `NSLocationAlwaysAndWhenInUseUsageDescription` in `info.plist`. If it has, it requests Always Authorization, otherwise (if the value is not defined, or `info.plist` doesn't exist), it requests When In Use Authorization.