### PR TITLE
Fixed location timestamp on iOS

### DIFF
--- a/compass-geolocation-mobile/src/iosMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
+++ b/compass-geolocation-mobile/src/iosMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
@@ -54,6 +54,6 @@ internal fun CLLocation.toModel(): Location {
         altitude = altitude,
         speed = speed,
         azimuth = azimuth,
-        timestampMillis = timestamp.timeIntervalSince1970.toLong(),
+        timestampMillis = timestamp.timeIntervalSince1970.toLong() * 1000L,
     )
 }


### PR DESCRIPTION
The location timestamp was in seconds on iOS, but should be in milliseconds to have consistent results with other platforms. This PR converts seconds to milliseconds on iOS.