### PR TITLE
Permission fix

### DIFF
--- a/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/internal/LocationPermissionManagerDelegate.kt
+++ b/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/mobile/internal/LocationPermissionManagerDelegate.kt
@@ -3,7 +3,6 @@ package dev.jordond.compass.permissions.mobile.internal
 import platform.CoreLocation.CLAuthorizationStatus
 import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.CLLocationManagerDelegateProtocol
-import platform.Foundation.NSBundle
 import platform.darwin.NSObject
 
 internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManagerDelegateProtocol {
@@ -12,16 +11,9 @@ internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManager
 
     private var permissionCallback: ((CLAuthorizationStatus) -> Unit)? = null
     private var requestPermissionCallback: ((CLAuthorizationStatus) -> Unit)? = null
-
-    private val useAlwaysAuthorization = canUseAlwaysAuthorization()
     
     init {
         manager.delegate = this
-    }
-
-    private fun canUseAlwaysAuthorization(): Boolean {
-        return NSBundle.mainBundle.infoDictionary
-            ?.containsKey("NSLocationAlwaysAndWhenInUseUsageDescription") ?: false
     }
 
     fun currentPermissionStatus(): CLAuthorizationStatus {
@@ -44,11 +36,7 @@ internal class LocationPermissionManagerDelegate : NSObject(), CLLocationManager
             callback(status)
             requestPermissionCallback = null
         }
-        
-        if (useAlwaysAuthorization) {
-            manager.requestAlwaysAuthorization()
-        } else {
-            manager.requestWhenInUseAuthorization()
-        }
+
+        manager.requestWhenInUseAuthorization()
     }
 }

--- a/demo/iosApp/iosApp/Info.plist
+++ b/demo/iosApp/iosApp/Info.plist
@@ -48,7 +48,5 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Its a demo about location</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>A demo about geolocation</string>
 </dict>
 </plist>

--- a/docs/setup/android-ios.md
+++ b/docs/setup/android-ios.md
@@ -48,17 +48,15 @@ On Android you don't need to declare any location permission in your manifest si
 
 #### iOS
 
-On iOS you are required to edit your `info.plist` and add the following entries:
+On iOS you are required to edit your `info.plist` and add the following entry:
 
 ```xml
 <key>NSLocationWhenInUseUsageDescription</key>
 <string>Add a description for why you need this permission</string>
-<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-<string>Add a description for why you need this permission</string>
 ```
 
 {% hint style="info" %}
-Make sure you change the description for both permissions. You are required to explain to your users why you need their location. Check out the [Documentation](https://developer.apple.com/documentation/corelocation/requesting\_authorization\_to\_use\_location\_services#3385302\)).
+Make sure you change the description for the permission. You are required to explain to your users why you need their location. Check out the [Documentation](https://developer.apple.com/documentation/corelocation/requesting\_authorization\_to\_use\_location\_services#3385302\)).
 {% endhint %}
 
-If you don't add these keys to your `info.plist`, you will encounter a runtime exception when requesting permissions.
+If you don't add this key to your `info.plist`, you will encounter a runtime exception when requesting permissions.


### PR DESCRIPTION
For some reason, my solution (#202) to checking if the user has defined `NSLocationAlwaysAndWhenInUseUsageDescription` in `info.plist` doesn't work on apps other than the demo app.

I noticed (correct me if I'm wrong) that this library doesn't track user location in the background anyway, as there is no `CLLocationManager.allowsBackgroundLocationUpdates = true`, so it makes sense to just not ask for Always Authorization. This will also make the behaviour on iOS consistent with Android, as the library doesn't ask for background location permission on Android.