### PR TITLE
[iOS] Fixed asking for permission when dialog dismissed

### DIFF
--- a/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/PermissionController.ios.kt
+++ b/compass-permissions-mobile/src/iosMain/kotlin/dev/jordond/compass/permissions/PermissionController.ios.kt
@@ -5,8 +5,6 @@ import dev.jordond.compass.permissions.mobile.internal.LocationPermissionManager
 import dev.jordond.compass.permissions.mobile.internal.toPermissionState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -17,8 +15,6 @@ internal actual fun createPermissionController(): LocationPermissionController {
 internal class IosLocationPermissionController(
     private val locationDelegate: LocationPermissionManagerDelegate,
 ) : LocationPermissionController {
-
-    private val mutex: Mutex = Mutex()
 
     private val _permissionsStatus = MutableStateFlow(
         value = locationDelegate.currentPermissionStatus().toPermissionState,
@@ -39,7 +35,7 @@ internal class IosLocationPermissionController(
         return when {
             currentState == PermissionState.Granted ||
                 currentState == PermissionState.DeniedForever -> currentState
-            else -> mutex.withLock {
+            else -> {
                 val result = suspendCoroutine { continuation ->
                     locationDelegate.requestPermission { continuation.resume(it) }
                 }


### PR DESCRIPTION
The permission dialog on iOS can be dismissed when you lock the screen. When you unlock again, the Mutex block you from asking the permission again. As a result, the user is unable to get the location. As far as I know (correct me if I'm wrong), iOS internally blocks you from opening 2 permission dialogs at the same time. Is there any other purpose of the mutex here? 

Treat it as a suggestion, as I'm not entirely sure of the purpose of the mutex here, so I don't know if this PR doesn't break anything I'm not aware of.