### PR TITLE
Made location return mslAltitude and ellipsoidalAltitude

### DIFF
--- a/compass-core/api/android/compass-core.api
+++ b/compass-core/api/android/compass-core.api
@@ -1,8 +1,8 @@
 public final class dev/jordond/compass/Altitude {
-	public fun <init> (DLjava/lang/Float;)V
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Float;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccuracy ()Ljava/lang/Float;
-	public final fun getMeters ()D
+	public final fun getMeters ()Ljava/lang/Double;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -29,12 +29,13 @@ public abstract interface annotation class dev/jordond/compass/InternalCompassAp
 }
 
 public final class dev/jordond/compass/Location {
-	public fun <init> (Ldev/jordond/compass/Coordinates;DLdev/jordond/compass/Azimuth;Ldev/jordond/compass/Speed;Ldev/jordond/compass/Altitude;J)V
+	public fun <init> (Ldev/jordond/compass/Coordinates;DLdev/jordond/compass/Azimuth;Ldev/jordond/compass/Speed;Ldev/jordond/compass/Altitude;Ldev/jordond/compass/Altitude;J)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccuracy ()D
-	public final fun getAltitude ()Ldev/jordond/compass/Altitude;
 	public final fun getAzimuth ()Ldev/jordond/compass/Azimuth;
 	public final fun getCoordinates ()Ldev/jordond/compass/Coordinates;
+	public final fun getEllipsoidalAltitude ()Ldev/jordond/compass/Altitude;
+	public final fun getMslAltitude ()Ldev/jordond/compass/Altitude;
 	public final fun getSpeed ()Ldev/jordond/compass/Speed;
 	public final fun getTimestampMillis ()J
 	public fun hashCode ()I

--- a/compass-core/api/jvm/compass-core.api
+++ b/compass-core/api/jvm/compass-core.api
@@ -1,8 +1,8 @@
 public final class dev/jordond/compass/Altitude {
-	public fun <init> (DLjava/lang/Float;)V
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Float;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccuracy ()Ljava/lang/Float;
-	public final fun getMeters ()D
+	public final fun getMeters ()Ljava/lang/Double;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -29,12 +29,13 @@ public abstract interface annotation class dev/jordond/compass/InternalCompassAp
 }
 
 public final class dev/jordond/compass/Location {
-	public fun <init> (Ldev/jordond/compass/Coordinates;DLdev/jordond/compass/Azimuth;Ldev/jordond/compass/Speed;Ldev/jordond/compass/Altitude;J)V
+	public fun <init> (Ldev/jordond/compass/Coordinates;DLdev/jordond/compass/Azimuth;Ldev/jordond/compass/Speed;Ldev/jordond/compass/Altitude;Ldev/jordond/compass/Altitude;J)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccuracy ()D
-	public final fun getAltitude ()Ldev/jordond/compass/Altitude;
 	public final fun getAzimuth ()Ldev/jordond/compass/Azimuth;
 	public final fun getCoordinates ()Ldev/jordond/compass/Coordinates;
+	public final fun getEllipsoidalAltitude ()Ldev/jordond/compass/Altitude;
+	public final fun getMslAltitude ()Ldev/jordond/compass/Altitude;
 	public final fun getSpeed ()Ldev/jordond/compass/Speed;
 	public final fun getTimestampMillis ()J
 	public fun hashCode ()I

--- a/compass-core/src/commonMain/kotlin/dev/jordond/compass/Location.kt
+++ b/compass-core/src/commonMain/kotlin/dev/jordond/compass/Location.kt
@@ -12,8 +12,11 @@ import dev.drewhamilton.poko.Poko
  * the accuracy of the location request.
  * @property speed The speed of the location in meters per second, this value can be empty depending
  * on the accuracy of the location request.
- * @property altitude The altitude of the location in meters, this value can be empty depending on
- * the accuracy of the location request.
+ * @property mslAltitude The altitude above mean sea level of the location in meters, this value can
+ * be empty depending on the accuracy of the location request.
+ * @property ellipsoidalAltitude The altitude as a height above the World Geodetic System 1984
+ * (WGS84) ellipsoid, measured in meters, this value can be empty depending on the accuracy of the
+ * location request.
  * @property timestampMillis The timestamp of the location in milliseconds since epoch.
  */
 @Poko
@@ -22,7 +25,8 @@ public class Location(
     public val accuracy: Double,
     public val azimuth: Azimuth?,
     public val speed: Speed?,
-    public val altitude: Altitude?,
+    public val mslAltitude: Altitude?,
+    public val ellipsoidalAltitude: Altitude?,
     public val timestampMillis: Long,
 )
 
@@ -64,6 +68,6 @@ public class Speed(
  */
 @Poko
 public class Altitude(
-    public val meters: Double,
+    public val meters: Double?,
     public val accuracy: Float?,
 )

--- a/compass-geolocation-browser/src/commonMain/kotlin/dev/jordond/compass/geolocation/browser/internal/Mapper.kt
+++ b/compass-geolocation-browser/src/commonMain/kotlin/dev/jordond/compass/geolocation/browser/internal/Mapper.kt
@@ -10,7 +10,8 @@ import dev.jordond.compass.geolocation.browser.api.model.GeolocationPosition
 internal fun GeolocationPosition.toModel(): Location = Location(
     coordinates = Coordinates(coords.latitude, coords.longitude),
     accuracy = coords.accuracy,
-    altitude = coords.altitude?.let { Altitude(it, coords.altitudeAccuracy?.toFloat()) },
+    mslAltitude = null,
+    ellipsoidalAltitude = coords.altitude?.let { Altitude(it, coords.altitudeAccuracy?.toFloat()) },
     azimuth = coords.heading?.let { Azimuth(it.toFloat(), null) },
     speed = coords.speed?.let { Speed(it.toFloat(), null) },
     timestampMillis = timestamp.toLong(),

--- a/compass-geolocation-mobile/build.gradle.kts
+++ b/compass-geolocation-mobile/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(libs.androidx.activity)
             implementation(libs.androidx.fragment)
             implementation(libs.androidx.startup)
+            implementation(libs.location.altitude)
         }
 
         iosMain.dependencies {

--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/MobileLocator.android.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/MobileLocator.android.kt
@@ -31,11 +31,11 @@ internal class AndroidLocator(
 ) : MobileLocator {
 
     override val locationUpdates: Flow<Location> = locationManager.locationUpdates
-        .mapNotNull { result -> result.lastLocation?.toModel() }
+        .mapNotNull { result -> result.lastLocation?.toModel(context) }
 
     override suspend fun lastLocation(priority: Priority): Location? {
         requirePermission(priority)
-        return locationManager.lastLocation()?.toModel()
+        return locationManager.lastLocation()?.toModel(context)
     }
 
     override suspend fun isAvailable(): Boolean {
@@ -48,7 +48,7 @@ internal class AndroidLocator(
 
     override suspend fun current(priority: Priority): Location {
         requirePermission(priority)
-        return locationManager.currentLocation(priority.toAndroidPriority).toModel()
+        return locationManager.currentLocation(priority.toAndroidPriority).toModel(context)
     }
 
     override suspend fun track(request: LocationRequest): Flow<Location> {

--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
@@ -1,36 +1,55 @@
 package dev.jordond.compass.geolocation.mobile.internal
 
+import android.content.Context
 import android.location.Location
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import androidx.core.location.LocationCompat
+import androidx.core.location.altitude.AltitudeConverterCompat.addMslAltitudeToLocation
 import com.google.android.gms.location.LocationRequest
 import dev.jordond.compass.Altitude
 import dev.jordond.compass.Azimuth
 import dev.jordond.compass.Coordinates
 import dev.jordond.compass.Priority
 import dev.jordond.compass.Speed
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import dev.jordond.compass.geolocation.LocationRequest as CompassLocationRequest
 
 /**
  * Converts a [Location] to a [dev.jordond.compass.Location].
  */
-internal fun Location.toModel(): dev.jordond.compass.Location = dev.jordond.compass.Location(
-    coordinates = Coordinates(latitude = latitude, longitude = longitude),
-    accuracy = accuracy.toDouble(),
-    azimuth = Azimuth(
-        degrees = bearing,
-        accuracy = if (VERSION.SDK_INT < VERSION_CODES.O) null else bearingAccuracyDegrees,
-    ),
-    speed = Speed(
-        mps = speed,
-        accuracy = if (VERSION.SDK_INT < VERSION_CODES.O) null else speedAccuracyMetersPerSecond,
-    ),
-    altitude = Altitude(
-        meters = altitude,
-        accuracy = if (VERSION.SDK_INT < VERSION_CODES.O) null else verticalAccuracyMeters,
-    ),
-    timestampMillis = time,
-)
+internal suspend fun Location.toModel(context: Context): dev.jordond.compass.Location {
+    return withContext(Dispatchers.IO) {
+        addMslAltitudeToLocation(context, this@toModel)
+
+        dev.jordond.compass.Location(
+            coordinates = Coordinates(latitude = latitude, longitude = longitude),
+            accuracy = accuracy.toDouble(),
+            azimuth = Azimuth(
+                degrees = bearing,
+                accuracy = if (VERSION.SDK_INT < VERSION_CODES.O) null else bearingAccuracyDegrees,
+            ),
+            speed = Speed(
+                mps = speed,
+                accuracy = if (VERSION.SDK_INT < VERSION_CODES.O)
+                    null else speedAccuracyMetersPerSecond,
+            ),
+            mslAltitude = Altitude(
+                meters = if (!LocationCompat.hasMslAltitude(this@toModel))
+                    null else LocationCompat.getMslAltitudeMeters(this@toModel),
+                accuracy = if (!LocationCompat.hasMslAltitudeAccuracy(this@toModel))
+                    null else LocationCompat.getMslAltitudeAccuracyMeters(this@toModel),
+            ),
+            ellipsoidalAltitude = Altitude(
+                meters = if (!hasAltitude()) null else altitude,
+                accuracy = if (VERSION.SDK_INT < VERSION_CODES.O || !hasVerticalAccuracy())
+                    null else verticalAccuracyMeters,
+            ),
+            timestampMillis = time,
+        )
+    }
+}
 
 internal val Priority.toAndroidPriority: Int
     get() = when (this) {

--- a/compass-geolocation-mobile/src/iosMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
+++ b/compass-geolocation-mobile/src/iosMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
@@ -58,10 +58,20 @@ internal fun CLLocation.toModel(): Location {
             )
         }
 
+    val ellipsoidalAltitude = verticalAccuracy.toFloat()
+        .takeIf { verticalAccuracyValue -> verticalAccuracyValue > 0.0 }
+        ?.let { verticalAccuracyValue ->
+            Altitude(
+                meters = ellipsoidalAltitude,
+                accuracy = verticalAccuracyValue,
+            )
+        }
+
     return Location(
         coordinates = coordinates,
         accuracy = horizontalAccuracy,
-        altitude = altitude,
+        mslAltitude = altitude,
+        ellipsoidalAltitude = ellipsoidalAltitude,
         speed = speed,
         azimuth = azimuth,
         timestampMillis = timestamp.timeIntervalSince1970.toLong() * 1000L,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ kotest = "5.9.1"
 ktor = "3.2.3"
 voyager = "1.1.0-beta03"
 stateHolder = "1.2.0"
+locationAltitude = "1.0.0-alpha03"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -61,6 +62,7 @@ gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref 
 gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradlePlugin-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
 gradlePlugin-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "publish" }
+location-altitude = { module = "androidx.core:core-location-altitude", version.ref = "locationAltitude" }
 
 [bundles]
 logic-plugins = ["gradlePlugin-android", "gradlePlugin-kotlin", "gradlePlugin-compose", "gradlePlugin-publish"]


### PR DESCRIPTION
There is a discrepancy between the altitude returned on Android and iOS. Android returns the altitude above the WGS84 reference ellipsoid ([docs](https://developer.android.com/reference/android/location/Location#getAltitude())), but iOS returns the altitude above mean sea level ([docs](https://developer.apple.com/documentation/corelocation/cllocation/altitude)).

The altitude above mean sea level is more common, so it's worth having it. This PR makes the library return both. 

I didn't implement web, because I don't have any experience with it. According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationCoordinates/altitude), web target returns the altitude above the WGS84, so the previous `altitude` is now under the `ellipsoidalAltitude`. `mslAltitude` on web returns `null` for now - implementation is to-do, after this PR is merged, I can open an issue.

There are 2 breaking changes in this PR:
1. There is no `Location.altitude` anymore, instead, there are 2 properties `Location.mslAltitude` and `Location.ellipsoidalAltitude`
2. `Altitude.meters` is now nullable