### PR TITLE
Validation of bearing and speed values on android

### DIFF
--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
@@ -40,25 +40,33 @@ internal suspend fun Location.toModel(context: Context): dev.jordond.compass.Loc
                 ),
             accuracy = location.accuracy.toDouble(),
             azimuth =
-                Azimuth(
-                    degrees = location.bearing,
-                    accuracy =
-                        if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasBearingAccuracy()) {
-                            null
-                        } else {
-                            location.bearingAccuracyDegrees
-                        },
-                ),
+                if (!hasBearing()) {
+                    null
+                } else {
+                    Azimuth(
+                        degrees = location.bearing,
+                        accuracy =
+                            if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasBearingAccuracy()) {
+                                null
+                            } else {
+                                location.bearingAccuracyDegrees
+                            }
+                    )
+                },
             speed =
-                Speed(
-                    mps = location.speed,
-                    accuracy =
-                        if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasSpeedAccuracy()) {
-                            null
-                        } else {
-                            location.speedAccuracyMetersPerSecond
-                        },
-                ),
+                if (!hasSpeed()) {
+                    null
+                } else {
+                    Speed(
+                        mps = location.speed,
+                        accuracy =
+                            if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasSpeedAccuracy()) {
+                                null
+                            } else {
+                                location.speedAccuracyMetersPerSecond
+                            },
+                    )
+                },
             mslAltitude =
                 Altitude(
                     meters =

--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
@@ -43,7 +43,7 @@ internal suspend fun Location.toModel(context: Context): dev.jordond.compass.Loc
                 Azimuth(
                     degrees = location.bearing,
                     accuracy =
-                        if (VERSION.SDK_INT < VERSION_CODES.O) {
+                        if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasBearingAccuracy()) {
                             null
                         } else {
                             location.bearingAccuracyDegrees
@@ -53,7 +53,7 @@ internal suspend fun Location.toModel(context: Context): dev.jordond.compass.Loc
                 Speed(
                     mps = location.speed,
                     accuracy =
-                        if (VERSION.SDK_INT < VERSION_CODES.O) {
+                        if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasSpeedAccuracy()) {
                             null
                         } else {
                             location.speedAccuracyMetersPerSecond


### PR DESCRIPTION
According to the documentation 
- [getBearing()](https://developer.android.com/reference/android/location/Location#getBearing()) is only valid when [hasBearing()](https://developer.android.com/reference/android/location/Location#hasBearing()) is `true`. It returns 0 otherwise.
- [getBearingAccuracyDegrees()](https://developer.android.com/reference/android/location/Location#getBearingAccuracyDegrees()) is only valid when [hasBearingAccuracy()](https://developer.android.com/reference/android/location/Location#hasBearingAccuracy()) is `true`. It returns 0 otherwise.
- [getSpeed()](https://developer.android.com/reference/android/location/Location#getSpeed()) is only valid when [hasSpeed()](https://developer.android.com/reference/android/location/Location#hasSpeed()) is `true`. It returns 0 otherwise.
-  [getSpeedAccuracyMetersPerSecond()](https://developer.android.com/reference/android/location/Location#getSpeedAccuracyMetersPerSecond()) is only valid when [hasSpeedAccuracy()](https://developer.android.com/reference/android/location/Location#hasSpeedAccuracy()) is `true`. It returns 0 otherwise.

This PR implements validation for all of these values. We now distinguish between a legitimate 0 and an invalid state, preventing misleading data.