### PR TITLE
Made `Altitude.meters` non-nullable

### DIFF
--- a/compass-core/api/jvm/compass-core.api
+++ b/compass-core/api/jvm/compass-core.api
@@ -1,8 +1,8 @@
 public final class dev/jordond/compass/Altitude {
-	public fun <init> (Ljava/lang/Double;Ljava/lang/Float;)V
+	public fun <init> (DLjava/lang/Float;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccuracy ()Ljava/lang/Float;
-	public final fun getMeters ()Ljava/lang/Double;
+	public final fun getMeters ()D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/compass-core/src/commonMain/kotlin/dev/jordond/compass/Location.kt
+++ b/compass-core/src/commonMain/kotlin/dev/jordond/compass/Location.kt
@@ -68,6 +68,6 @@ public class Speed(
  */
 @Poko
 public class Altitude(
-    public val meters: Double?,
+    public val meters: Double,
     public val accuracy: Float?,
 )

--- a/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
+++ b/compass-geolocation-mobile/src/androidMain/kotlin/dev/jordond/compass/geolocation/mobile/internal/Mapper.kt
@@ -68,30 +68,33 @@ internal suspend fun Location.toModel(context: Context): dev.jordond.compass.Loc
                     )
                 },
             mslAltitude =
-                Altitude(
-                    meters =
-                        if (!LocationCompat.hasMslAltitude(location)) {
-                            null
-                        } else {
-                            LocationCompat.getMslAltitudeMeters(location)
-                        },
-                    accuracy =
-                        if (!LocationCompat.hasMslAltitudeAccuracy(location)) {
-                            null
-                        } else {
-                            LocationCompat.getMslAltitudeAccuracyMeters(location)
-                        },
-                ),
+                if (!LocationCompat.hasMslAltitude(location)) {
+                    null
+                } else {
+                    Altitude(
+                        meters = LocationCompat.getMslAltitudeMeters(location),
+                        accuracy =
+                            if (!LocationCompat.hasMslAltitudeAccuracy(location)) {
+                                null
+                            } else {
+                                LocationCompat.getMslAltitudeAccuracyMeters(location)
+                            }
+                    )
+                },
             ellipsoidalAltitude =
-                Altitude(
-                    meters = if (!location.hasAltitude()) null else location.altitude,
-                    accuracy =
-                        if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasVerticalAccuracy()) {
-                            null
-                        } else {
-                            location.verticalAccuracyMeters
-                        },
-                ),
+                if (!location.hasAltitude()) {
+                    null
+                } else {
+                    Altitude(
+                        meters = location.altitude,
+                        accuracy =
+                            if (VERSION.SDK_INT < VERSION_CODES.O || !location.hasVerticalAccuracy()) {
+                                null
+                            } else {
+                                location.verticalAccuracyMeters
+                            },
+                    )
+                },
             timestampMillis = location.time,
         )
     }


### PR DESCRIPTION
Refactored the handling of empty altitude data on Android. Instead of returning an `Altitude` object with null properties, it now returns a top-level null. This change enables the removal of nullability from the `Altitude.meters` property.